### PR TITLE
Handle multi-digit version numbers

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -6,7 +6,7 @@ require './lib/version'
 class GitApp < Sinatra::Base
 
   def get_version
-    if v = Version.last(:order => [:version])
+    if v = Version.all.sort.last
       @version = v.version
       @date = v.created_at.strftime("%Y-%m-%d")
     end


### PR DESCRIPTION
The first patch is something I'd had lying around and made sense to include here. I can prepare the second patch to simply handle the 1.7.10 version number on top of your master if you don't want the first one.
